### PR TITLE
Adds support for terminating the connection aggressively.

### DIFF
--- a/source/http-server.js
+++ b/source/http-server.js
@@ -44,6 +44,7 @@ HttpServer.prototype.constructor = HttpServer;
 HttpServer.prototype.makeRequest = function (jso) { }
 
 HttpServer.prototype.destroy = function (callback) {
+  if (!this.underlyingServer.listening) return callback();
   this.underlyingServer.close(callback);
   for (var key in this.outstandingSockets) {
     this.outstandingSockets[key].destroy();

--- a/source/ws-server.js
+++ b/source/ws-server.js
@@ -12,7 +12,12 @@ function WsServer(address) {
   this.underlyingServer.on('connection', function (webSocket) {
     var key = this.nextKey++;
     var outboundChannel = function (json) {
-      webSocket.send(json);
+      webSocket.send(json, {}, (maybeError) => {
+        if (!maybeError) return;
+        // "not opened" means the connection was closed before we could send a response, in this case just drop the response
+        if (maybeError.message === "not opened") return;
+        throw maybeError;
+      });
     }.bind(this);
     this.activeOutboundChannels[key] = outboundChannel;
     this.outstandingSockets[key] = webSocket;


### PR DESCRIPTION
If you terminate the WebSocket connection after putting your request on the wire but before the stub server can respond, the server will choke complaining about the connection being closed.  Since in testing it is not uncommon to sever the connection abruptly, the stub server should gracefully deal with this scenario.

Also added support for calling destroy multiple times (HTTP didn't like it much).